### PR TITLE
Passing in a buffer scratchpad used in computing FFT and IFFT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 script: make travis-ci
 
 go:
-  - "1.12"
+  - "1.13"
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -98,16 +98,16 @@ func main() {
 ## Benchmarks
 Benchmark name                      | NumReps |    Time/Rep    |   Memory/Rep  |     Alloc/Rep   |
 -----------------------------------:|--------:|---------------:|--------------:|----------------:|
-BenchmarkMuseRun-4                  |    50000|     37319 ns/op|      9626 B/op|    112 allocs/op| 
-BenchmarkMuseRunLarge-4             |       10| 184963980 ns/op| 133454180 B/op|  32001 allocs/op|
-BenchmarkFilterByLabelValues-4      |  2000000|       569 ns/op|       496 B/op|      8 allocs/op|
-BenchmarkIndexLabelValues-4         |   500000|      2709 ns/op|      2152 B/op|     38 allocs/op|
-BenchmarkZPad-4                     | 30000000|      40.8 ns/op|        80 B/op|      1 allocs/op|
-BenchmarkZNormalize-4               | 20000000|      63.4 ns/op|         0 B/op|      0 allocs/op|
-BenchmarkXCorr-4                    |      300|   5651196 ns/op|   2114464 B/op|      7 allocs/op|
-BenchmarkXCorrWithX-4               |      500|   3508246 ns/op|    799391 B/op|      3 allocs/op|
+BenchmarkMuseRun-4                  |   223243|      4515 ns/op|      2064 B/op|     26 allocs/op| 
+BenchmarkMuseRunLarge-4             |        9| 113956001 ns/op|  25155107 B/op|  10420 allocs/op|
+BenchmarkFilterByLabelValues-4      |  1840992|       635 ns/op|       496 B/op|      8 allocs/op|
+BenchmarkIndexLabelValues-4         |   414496|      2921 ns/op|      2152 B/op|     38 allocs/op|
+BenchmarkZPad-4                     | 25136180|      41.3 ns/op|        80 B/op|      1 allocs/op|
+BenchmarkZNormalize-4               | 17526874|      61.6 ns/op|         0 B/op|      0 allocs/op|
+BenchmarkXCorr-4                    |      193|   6101637 ns/op|   2114979 B/op|      7 allocs/op|
+BenchmarkXCorrWithX-4               |      309|   3878212 ns/op|    271582 B/op|      1 allocs/op|
 
-Ran on a 2018 MacBookAir on Jul 21, 2019
+Ran on a 2018 MacBookAir on Apr 17, 2020
 ```sh
     Processor: 1.6 GHz Intel Core i5
        Memory: 8GB 2133 MHz LPDDR3

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/google/uuid v1.1.1
-	github.com/matrix-profile-foundation/go-matrixprofile v0.2.0
-	gonum.org/v1/gonum v0.6.2
+	github.com/matrix-profile-foundation/go-matrixprofile v0.4.2
+	gonum.org/v1/gonum v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/matrix-profile-foundation/go-matrixprofile v0.2.0 h1:CMzuMaH5YzhgfnNl8+YUnjcWHYu9WzBBYciOmRsRGU0=
 github.com/matrix-profile-foundation/go-matrixprofile v0.2.0/go.mod h1:+C7pWj4uDm6lWE9lIMMQa/VI8LTPLNxdapeAZvtxoxU=
+github.com/matrix-profile-foundation/go-matrixprofile v0.4.2 h1:CcnXjJnUvJBZ/dtH5DmBZL0+/+EyAHS1vUnS+lsg8O4=
+github.com/matrix-profile-foundation/go-matrixprofile v0.4.2/go.mod h1:G2HVmlzzo7MMG6NsDWOg/Ad+0NEc1kdqmlYzOYx7GlY=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2 h1:y102fOLFqhV41b+4GPiJoa0k/x+pJcEi2/HB1Y5T6fU=
@@ -18,6 +20,8 @@ gonum.org/v1/gonum v0.0.0-20190722130455-b16c96abd880 h1:QvhI5vANyNUj5h5MA1fqHgW
 gonum.org/v1/gonum v0.0.0-20190722130455-b16c96abd880/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=
 gonum.org/v1/gonum v0.6.2 h1:4r+yNT0+8SWcOkXP+63H2zQbN+USnC73cjGUxnDF94Q=
 gonum.org/v1/gonum v0.6.2/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=
+gonum.org/v1/gonum v0.7.0 h1:Hdks0L0hgznZLG9nzXb8vZ0rRvqNvAcgAp84y7Mwkgw=
+gonum.org/v1/gonum v0.7.0/go.mod h1:L02bwd0sqlsvRv41G7wGWFCsVNZFv/k1xzGIxeANHGM=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=

--- a/muse.go
+++ b/muse.go
@@ -48,6 +48,8 @@ func (m *Muse) Run(compGraphs []*Series) error {
 
 	maxScore := Score{}
 	ft := fourier.NewFFT(m.n)
+	coefScratch := make([]complex128, m.n/2+1)
+	seqScratch := make([]float64, m.n)
 
 	// for each time series, store the time series with highest relationship
 	// with the reference time series
@@ -56,7 +58,7 @@ func (m *Muse) Run(compGraphs []*Series) error {
 		// comparison time series. boolean value specifies that we are normalizing
 		// the the time series so that the power of of the reference and comparison
 		// is equivalent. output value will range between 0 and 1 due to normalizing
-		_, lag, maxVal = xCorrWithX(m.x, compTs.Values(), ft)
+		_, lag, maxVal = xCorrWithX(m.x, compTs.Values(), ft, coefScratch, seqScratch)
 		maxVal = math.Abs(maxVal)
 		if maxVal > 1.0 {
 			maxVal = 1.0

--- a/muse.go
+++ b/muse.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"math"
 
+	"gonum.org/v1/gonum/dsp/fourier"
 	"gonum.org/v1/gonum/floats"
-	"gonum.org/v1/gonum/fourier"
 )
 
 // Muse is the primary struct to setup and run a z-normalized cross correlation between a
@@ -48,6 +48,8 @@ func (m *Muse) Run(compGraphs []*Series) error {
 
 	maxScore := Score{}
 	ft := fourier.NewFFT(m.n)
+	coefScratch := make([]complex128, m.n/2+1)
+	seqScratch := make([]float64, m.n)
 
 	// for each time series, store the time series with highest relationship
 	// with the reference time series
@@ -56,7 +58,7 @@ func (m *Muse) Run(compGraphs []*Series) error {
 		// comparison time series. boolean value specifies that we are normalizing
 		// the the time series so that the power of of the reference and comparison
 		// is equivalent. output value will range between 0 and 1 due to normalizing
-		_, lag, maxVal = xCorrWithX(m.x, compTs.Values(), ft)
+		_, lag, maxVal = xCorrWithX(m.x, compTs.Values(), ft, coefScratch, seqScratch)
 		maxVal = math.Abs(maxVal)
 		if maxVal > 1.0 {
 			maxVal = 1.0

--- a/muse_batch.go
+++ b/muse_batch.go
@@ -60,7 +60,8 @@ func (b *Batch) scoreSingle(idx int, labelValues *Labels, sem chan struct{}, gra
 
 	maxScore := Score{}
 	ft := fourier.NewFFT(b.n)
-
+	coefScratch := make([]complex128, b.n/2+1)
+	seqScratch := make([]float64, b.n)
 	compGraphs := b.Comparison.FilterByLabelValues(labelValues)
 	// for each time series, store the time series with highest relationship
 	// with the reference time series
@@ -69,7 +70,7 @@ func (b *Batch) scoreSingle(idx int, labelValues *Labels, sem chan struct{}, gra
 		// comparison time series. boolean value specifies that we are normalizing
 		// the the time series so that the power of of the reference and comparison
 		// is equivalent. output value will range between 0 and 1 due to normalizing
-		_, lag, maxVal = xCorrWithX(b.x, compTs.Values(), ft)
+		_, lag, maxVal = xCorrWithX(b.x, compTs.Values(), ft, coefScratch, seqScratch)
 		maxVal = math.Abs(maxVal)
 		if maxVal > 1.0 {
 			maxVal = 1.0

--- a/xcorr.go
+++ b/xcorr.go
@@ -7,8 +7,8 @@ import (
 	"math"
 	"math/cmplx"
 
+	"gonum.org/v1/gonum/dsp/fourier"
 	"gonum.org/v1/gonum/floats"
-	"gonum.org/v1/gonum/fourier"
 	"gonum.org/v1/gonum/stat"
 )
 
@@ -28,7 +28,7 @@ func prettyClose(a, b []float64) bool {
 		return false
 	}
 	for i, v := range a {
-		if math.Abs(v-b[i]) > 1E-8 {
+		if math.Abs(v-b[i]) > 1e-8 {
 			return false
 		}
 	}
@@ -154,8 +154,10 @@ func xCorr(x []float64, y []float64, n int, normalize bool) ([]float64, int, flo
 
 // xCorrWithX allows a precomputed FFT of X to be passed in for the purposes of batch
 // execution and not repeatedly calculating FFT(x). Must pass in the fourier transform
-// struct used to compute X.
-func xCorrWithX(X []complex128, y []float64, ft *fourier.FFT) ([]float64, int, float64) {
+// struct used to compute X. coefScratch and seqScratch are scratchpads for computing the
+// coefficients and sequence ffts. This reuse of the buffer cuts down on having to
+// reallocate a new buffer on each fourier computation.
+func xCorrWithX(X []complex128, y []float64, ft *fourier.FFT, coefScratch []complex128, seqScratch []float64) ([]float64, int, float64) {
 	var err error
 
 	n := ft.Len()
@@ -170,10 +172,10 @@ func xCorrWithX(X []complex128, y []float64, ft *fourier.FFT) ([]float64, int, f
 	}
 	y = zeroPad(y, n)
 
-	C := ft.Coefficients(nil, y)
+	C := ft.Coefficients(coefScratch, y)
 	conj(C)
 	mult(C, X)
-	cc := ft.Sequence(nil, C)
+	cc := ft.Sequence(seqScratch, C)
 	floats.Scale(1.0/float64(n), cc)
 
 	mi := maxAbsIndex(cc)

--- a/xcorr.go
+++ b/xcorr.go
@@ -155,7 +155,7 @@ func xCorr(x []float64, y []float64, n int, normalize bool) ([]float64, int, flo
 // xCorrWithX allows a precomputed FFT of X to be passed in for the purposes of batch
 // execution and not repeatedly calculating FFT(x). Must pass in the fourier transform
 // struct used to compute X.
-func xCorrWithX(X []complex128, y []float64, ft *fourier.FFT) ([]float64, int, float64) {
+func xCorrWithX(X []complex128, y []float64, ft *fourier.FFT, coefScratch []complex128, seqScratch []float64) ([]float64, int, float64) {
 	var err error
 
 	n := ft.Len()
@@ -170,10 +170,10 @@ func xCorrWithX(X []complex128, y []float64, ft *fourier.FFT) ([]float64, int, f
 	}
 	y = zeroPad(y, n)
 
-	C := ft.Coefficients(nil, y)
+	C := ft.Coefficients(coefScratch, y)
 	conj(C)
 	mult(C, X)
-	cc := ft.Sequence(nil, C)
+	cc := ft.Sequence(seqScratch, C)
 	floats.Scale(1.0/float64(n), cc)
 
 	mi := maxAbsIndex(cc)

--- a/xcorr_test.go
+++ b/xcorr_test.go
@@ -266,7 +266,9 @@ func TestXCorrWithX(t *testing.T) {
 		refFT := ft.Coefficients(nil, zeroPad(x, n))
 
 		ftY := fourier.NewFFT(n)
-		xcorr, mi, mv := xCorrWithX(refFT, ds.Y, ftY)
+		coefScratch := make([]complex128, n/2+1)
+		seqScratch := make([]float64, n)
+		xcorr, mi, mv := xCorrWithX(refFT, ds.Y, ftY, coefScratch, seqScratch)
 
 		if !prettyClose(xcorr, ds.ExpectedXCorr) {
 			t.Errorf("Expected cross correlation of %v, but got %v", ds.ExpectedXCorr, xcorr)
@@ -328,8 +330,10 @@ func BenchmarkXCorrWithX(b *testing.B) {
 	X := ft.Coefficients(nil, zeroPad(x, n))
 
 	ftY := fourier.NewFFT(n)
-	for i := 0; i < b.N; i++ {
-		xCorrWithX(X, y, ftY)
+	coefScratch := make([]complex128, n/2+1)
+	seqScratch := make([]float64, n)
 
+	for i := 0; i < b.N; i++ {
+		xCorrWithX(X, y, ftY, coefScratch, seqScratch)
 	}
 }

--- a/xcorr_test.go
+++ b/xcorr_test.go
@@ -5,8 +5,8 @@ import (
 	"math/rand"
 	"testing"
 
+	"gonum.org/v1/gonum/dsp/fourier"
 	"gonum.org/v1/gonum/floats"
-	"gonum.org/v1/gonum/fourier"
 )
 
 func isPositive() func(float64) bool {
@@ -53,7 +53,7 @@ func TestZNormalize(t *testing.T) {
 		for i := 0; i < len(d.ts); i++ {
 			ssum += d.ts[i] * d.ts[i]
 		}
-		if math.Abs(ssum-float64(len(d.ts)-1)) > 1E-8 {
+		if math.Abs(ssum-float64(len(d.ts)-1)) > 1e-8 {
 			t.Errorf("Expected a squared sum of %d, but got %.3f for %v", len(d.ts), ssum, d.ts)
 		}
 	}
@@ -266,7 +266,9 @@ func TestXCorrWithX(t *testing.T) {
 		refFT := ft.Coefficients(nil, zeroPad(x, n))
 
 		ftY := fourier.NewFFT(n)
-		xcorr, mi, mv := xCorrWithX(refFT, ds.Y, ftY)
+		coefScratch := make([]complex128, n/2+1)
+		seqScratch := make([]float64, n)
+		xcorr, mi, mv := xCorrWithX(refFT, ds.Y, ftY, coefScratch, seqScratch)
 
 		if !prettyClose(xcorr, ds.ExpectedXCorr) {
 			t.Errorf("Expected cross correlation of %v, but got %v", ds.ExpectedXCorr, xcorr)
@@ -328,8 +330,10 @@ func BenchmarkXCorrWithX(b *testing.B) {
 	X := ft.Coefficients(nil, zeroPad(x, n))
 
 	ftY := fourier.NewFFT(n)
-	for i := 0; i < b.N; i++ {
-		xCorrWithX(X, y, ftY)
+	coefScratch := make([]complex128, n/2+1)
+	seqScratch := make([]float64, n)
 
+	for i := 0; i < b.N; i++ {
+		xCorrWithX(X, y, ftY, coefScratch, seqScratch)
 	}
 }


### PR DESCRIPTION
* Initialize a scratchpad for the FFT and IFFT operations which will be used in a single run
* Reduced number of allocations from 3 to 1 for xCorrWithX